### PR TITLE
pi-heif 0.21.0 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -3,7 +3,3 @@ build_env_vars:
 
 upload_channels:
   - sfe1ed40
-
-channels:
-  - https://staging.continuum.io/prefect/fs/libheif-feedstock/pr1/19beb6c
-  - https://staging.continuum.io/prefect/fs/x265-feedstock/pr1/0acc1f6

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes
+
+upload_channels:
+  - sfe1ed40
+
+channels:
+  - https://staging.continuum.io/prefect/fs/libheif-feedstock/pr1/30e2afa
+  - https://staging.continuum.io/prefect/fs/x265-feedstock/pr1/b608b1e

--- a/abs.yaml
+++ b/abs.yaml
@@ -5,5 +5,5 @@ upload_channels:
   - sfe1ed40
 
 channels:
-  - https://staging.continuum.io/prefect/fs/libheif-feedstock/pr1/30e2afa
-  - https://staging.continuum.io/prefect/fs/x265-feedstock/pr1/b608b1e
+  - https://staging.continuum.io/prefect/fs/libheif-feedstock/pr1/19beb6c
+  - https://staging.continuum.io/prefect/fs/x265-feedstock/pr1/0acc1f6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,17 +18,17 @@ build:
 
 requirements:
   build:
-    - {{ compiler('cxx') }}
+    - {{ compiler('c') }}
   host:
     - python
     - setuptools >=67.8
     - wheel
     - pip
-    - libheif >=1.17.0
+    - libheif 1.19.5
   run:
     - python
     - pillow >=10.1.0
-    - libheif >=1.17.0
+    - libheif
 
 test:
   source_files:
@@ -54,7 +54,12 @@ about:
     - pi-heif/LICENSES_bundled.txt
     - tests/images/heif_other/avif/LICENSE.txt
     - tests/images/heif_other/nokia/COPYRIGHT.txt
-  doc_url: https://pillow-heif.readthedocs.io/en/latest/
+  doc_url: https://pillow-heif.readthedocs.io
+  description: |
+    This is a light version of Pillow-Heif with more permissive license for binary wheels.
+    It includes only HEIF decoder and does not support save operations.
+    All codebase are the same, refer to pillow-heif docs
+    The only difference is the name of the imported project.
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,6 +50,8 @@ about:
   license_family: BSD
   license_file:
     - LICENSE.txt
+    - LICENSES_bundled.txt
+    - pi-heif/LICENSES_bundled.txt
     - tests/images/heif_other/avif/LICENSE.txt
     - tests/images/heif_other/nokia/COPYRIGHT.txt
   doc_url: https://pillow-heif.readthedocs.io/en/latest/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,55 @@
+{% set name = "pi-heif" %}
+{% set version = "0.21.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pi_heif-{{ version }}.tar.gz
+  sha256: 4902cdb84e75505e1d9abdd5aff1e6dcfebe569ec825162d68a4a399a43689a4
+
+build:
+  skip: true  # [py<39]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+  host:
+    - python
+    - setuptools >=67.8
+    - wheel
+    - pip
+    - libheif >=1.17.0
+  run:
+    - python
+    - pillow >=10.1.0
+    - libheif >=1.17.0
+
+test:
+  source_files:
+    - tests
+  imports:
+    - pi_heif
+  commands:
+    - pip check
+    - pytest tests
+  requires:
+    - pip
+    - pytest
+
+about:
+  home: https://github.com/bigcat88/pillow_heif
+  summary: Python interface for libheif library
+  dev_url: https://github.com/bigcat88/pillow_heif
+  license: BSD-3-Clause AND BSD-3-Clause-flex AND EPL-2.0
+  license_file:
+    - LICENSE.txt
+    - tests/images/heif_other/avif/LICENSE.txt
+    - tests/images/heif_other/nokia/COPYRIGHT.txt
+
+extra:
+  recipe-maintainers:
+    - Cansisti

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,9 @@ source:
   sha256: 4902cdb84e75505e1d9abdd5aff1e6dcfebe569ec825162d68a4a399a43689a4
 
 build:
-  skip: true  # [py<39 or s390x]
+  # s390x is missing libheif
+  # windows build requires msys2
+  skip: true  # [py<39 or s390x or win]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 4902cdb84e75505e1d9abdd5aff1e6dcfebe569ec825162d68a4a399a43689a4
 
 build:
-  skip: true  # [py<39]
+  skip: true  # [py<39 or s390x]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,7 +51,6 @@ about:
   license_file:
     - LICENSE.txt
     - LICENSES_bundled.txt
-    - pi-heif/LICENSES_bundled.txt
     - tests/images/heif_other/avif/LICENSE.txt
     - tests/images/heif_other/nokia/COPYRIGHT.txt
   doc_url: https://pillow-heif.readthedocs.io

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
   host:
     - python
     - setuptools >=67.8

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,10 +45,12 @@ about:
   summary: Python interface for libheif library
   dev_url: https://github.com/bigcat88/pillow_heif
   license: BSD-3-Clause AND BSD-3-Clause-flex AND EPL-2.0
+  license_family: BSD
   license_file:
     - LICENSE.txt
     - tests/images/heif_other/avif/LICENSE.txt
     - tests/images/heif_other/nokia/COPYRIGHT.txt
+  doc_url: https://pillow-heif.readthedocs.io/en/latest/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
pi-heif 0.21.0 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-6313]
- dev_url:        https://github.com/bigcat88/pillow_heif/tree/v0.21.0
- conda_forge:    None
- pypi:           https://pypi.org/project/pi-heif/0.21.0
- pypi inspector: https://inspector.pypi.io/project/pi-heif/0.21.0

### Explanation of changes:

- new version number


[PKG-6313]: https://anaconda.atlassian.net/browse/PKG-6313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ